### PR TITLE
Strip a last linebreak

### DIFF
--- a/lib/puppet/reports/slack.rb
+++ b/lib/puppet/reports/slack.rb
@@ -25,6 +25,7 @@ Provisioned Host   = %s
 Run Environment    = %s
 ```
     FORMAT
+    message.strip!
     color = nil
 
     if statuses.include?(self.status)


### PR DESCRIPTION
In Slack, the content will automatically collapse if 5+ linebreaks, and will display a "Show more..." link.
Stripping a last linebreak of `message`, it won't display a "Show more..." link.

`````` rb
irb(main):001:0> message = <<-FORMAT
irb(main):002:0" ```
irb(main):003:0" Puppet Master Host = %s
irb(main):004:0" Provisioned Host   = %s
irb(main):005:0" Run Environment    = %s
irb(main):006:0" ```
irb(main):007:0" FORMAT
=> "```\nPuppet Master Host = %s\nProvisioned Host   = %s\nRun Environment    = %s\n```\n"
irb(main):008:0> message.count("\n")
=> 5
irb(main):009:0> message.strip.count("\n")
=> 4
``````
