### PR TITLE
return_url have empty string at least.

### DIFF
--- a/lib/puppet/reports/slack.rb
+++ b/lib/puppet/reports/slack.rb
@@ -14,7 +14,7 @@ Puppet::Reports.register_report(:slack) do
 
     @config["statuses"] ||= "changed,failed"
     statuses = @config["statuses"].split(",")
-    report_url = @config["report_url"]
+    report_url = @config["report_url"] || ''
     if report_url.include? '%h'
       report_url ["%h"] = self.host
     end


### PR DESCRIPTION
If no `report_url` key is in a config file, `report_url.include?` fails.
This patch sets empty string to `report_url` when `@config["report_url"]` is nil.
