### PR TITLE
Remove unused "puppet/network/http_pool"

### DIFF
--- a/lib/puppet/reports/slack.rb
+++ b/lib/puppet/reports/slack.rb
@@ -1,5 +1,4 @@
 require 'puppet'
-require 'puppet/network/http_pool'
 require 'net/https'
 require 'uri'
 require 'json'


### PR DESCRIPTION
Hi @udzura-san. I removed `require 'puppet/network/http_pool'` because Puppet::Network::HttpPool is not used in this module.