### PR TITLE
Enhancements to module setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ puppet module install udzura-report_slack2
 Create config file `/etc/puppet/slack.yaml` as:
 
 ```yaml
---- 
+---
 username: "puppet reporter"
 webhook: "https://hooks.slack.com/services/YOUR/incoming-web-hook/AddRess!!!"
-channels: 
+channels:
   - "#udzura_dev"
 report_url: 'https://puppetdashboard.example.jp/reports'
 
@@ -32,16 +32,12 @@ report_url: 'https://puppetdashboard.example.jp/reports'
 Puppet way, like this:
 
 ```puppet
-$slack = {
-  username => "puppet reporter",
-  webhook  => "https://hooks.slack.com/services/YOUR/incoming-web-hook/AddRess!!!",
-  channels => ["#udzura_dev"],
-  report_url => 'https://puppetdashboard.example.jp/reports'
-}
 
-file {
-  '/etc/puppet/slack.yaml':
-    content => inline_template("<%= YAML.dump(@slack) %>")
+class { 'report_slack2' :
+  username   => 'puppet reporter',
+  webhook    => 'https://hooks.slack.com/services/YOUR/incoming-web-hook/AddRess!!!',
+  channels   => [ "#udzura_dev" ],
+  report_url => 'https://puppetdashboard.example.jp/reports',
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,2 +1,30 @@
-class report_slack2 {
+class report_slack2 (
+  $username   = undef,
+  $webhook    = undef,
+  $channels   = [],
+  $report_url = undef,
+) {
+
+  $slack_puppet_confdir = $::puppet_confdir
+
+  $slack = {
+    username    => $username,
+    webhook     => $webhook,
+    channels    => $channels,
+    report_url  => $report_url
+  }
+
+  file { "${slack_puppet_confdir}/slack.yaml":
+    content     => inline_template('<%= YAML.dump(@slack) %>')
+  }
+
+  ini_subsetting { 'puppet.conf/reports/slack':
+    ensure                => present,
+    path                  => "${slack_puppet_confdir}/puppet.conf",
+    section               => 'master',
+    setting               => 'reports',
+    subsetting            => 'slack',
+    subsetting_separator  => ',',
+    require               => File [ "${slack_puppet_confdir}/slack.yaml"],
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,10 +2,10 @@ class report_slack2 (
   $username   = undef,
   $webhook    = undef,
   $channels   = [],
-  $report_url = undef,
+  $report_url = '',
 ) {
 
-  $slack_puppet_confdir = $::puppet_confdir
+  $slack_puppet_confdir = "/etc/puppetlabs/puppet"
 
   $slack = {
     username    => $username,
@@ -18,13 +18,22 @@ class report_slack2 (
     content     => inline_template('<%= YAML.dump(@slack) %>')
   }
 
+  ini_subsetting { 'puppet.conf/report/true':
+    ensure               => present,
+    path                 => "${slack_puppet_confdir}/puppet.conf",
+    section              => 'master',
+    setting              => 'report',
+    subsetting           => 'true',
+    subsetting_separator => ',',
+  }->
+
   ini_subsetting { 'puppet.conf/reports/slack':
-    ensure                => present,
-    path                  => "${slack_puppet_confdir}/puppet.conf",
-    section               => 'master',
-    setting               => 'reports',
-    subsetting            => 'slack',
-    subsetting_separator  => ',',
-    require               => File [ "${slack_puppet_confdir}/slack.yaml"],
+    ensure               => present,
+    path                 => "${slack_puppet_confdir}/puppet.conf",
+    section              => 'master',
+    setting              => 'reports',
+    subsetting           => 'slack',
+    subsetting_separator => ',',
+    require              => File[ "${slack_puppet_confdir}/slack.yaml" ],
   }
 }


### PR DESCRIPTION
I have made some enhancements to how you setup the slack notifications. Now all that you have to do is the following on the puppet master.

```puppet
class { 'report_slack2' :
  username   => 'puppet reporter',
  webhook    => 'https://hooks.slack.com/services/YOUR/incoming-web-hook/AddRess!!!',
  channels   => [ "#udzura_dev" ],
  report_url => 'https://puppetdashboard.example.jp/reports',
 }
```

This will make the `slack.yaml` file in `/etc/puppetlabs/puppet/slack.yaml` and setups up the reports.

Some notes: I have only tested this with Puppet 4. I don't think it would work with Puppet 3. I also don't have it store any of the reports. In my setup I have the `PuppetDB` module to do that.