### PR TITLE
Use `Puppet::Util::Execution.execute`

### DIFF
--- a/lib/puppet/reports/slack.rb
+++ b/lib/puppet/reports/slack.rb
@@ -18,8 +18,8 @@ Puppet::Reports.register_report(:slack) do
       report_url ["%h"] = self.host
     end
 
-    # Kernel#` should always run on puppetserver host
-    puppetmaster_hostname = `hostname`.chomp
+    # See https://tickets.puppetlabs.com/browse/SERVER-2166
+    puppetmaster_hostname = Puppet::Util::Execution.execute('/bin/hostname').chomp
     pretxt = "Puppet status: *%s*" % self.status
     if !report_url.to_s.empty?
       message = <<-FORMAT % [puppetmaster_hostname, self.host, self.environment, report_url]


### PR DESCRIPTION
When the puppetserver uses jruby 9k, this report processor often fails
with...

```
Puppet Report processor failed: Cannot allocate memory - hostname
```

This is because the entire jvm process is forked just in order to run
the `hostname` command.  JRuby9k is the default in Puppet Server 6 and
has also been the default in Puppet Enterprise for a while now.

The issue is especially noticable if Puppet Server is configured with a
large Java heap. (eg. when running with an 8GB heap, a whole extra 8GB
will be allocated when forking the process).

See https://tickets.puppetlabs.com/browse/SERVER-2166